### PR TITLE
Don't joinFavorite

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -138,13 +138,7 @@ manageConnection = (retryCallback) ->
 			iptables.flushAsync('nat', 'TETHER')
 		.then ->
 			if !properties.connected
-				console.log('Trying to join wifi')
-				wifi.joinFavoriteAsync()
-				.then ->
-					console.log('Joined! Exiting.')
-					retryCallback()
-				.catch (err) ->
-					connectOrStartServer(wifi, retryCallback)
+				connectOrStartServer(wifi, retryCallback)
 			else
 				console.log('Already connected')
 				retryCallback()


### PR DESCRIPTION
There's no need to call joinFavorite - if connman has a favorite network, it will already have joined at boot (unless it is badly configured). Previous networks will now be joined as per the connectionFile.
This should optimize start up time a bit.

This will also fix #10 in the meantime, while Doodle3D/connman-simplified#18 is merged and published.