### PR TITLE
Don't crash with no networks

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -51,7 +51,10 @@ getIptablesRules = (callback) ->
 
 startServer = (wifi) ->
 	console.log('Getting networks list')
-	wifi.getNetworksAsync().then (list) ->
+	wifi.getNetworksAsync()
+	.catch (err) ->
+		throw err unless err.message == 'No WiFi networks found'
+	.then (list) ->
 		ssidList = list
 		wifi.openHotspotAsync(ssid, passphrase)
 	.then ->

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -54,6 +54,7 @@ startServer = (wifi) ->
 	wifi.getNetworksAsync()
 	.catch (err) ->
 		throw err unless err.message == 'No WiFi networks found'
+		return []
 	.then (list) ->
 		ssidList = list
 		wifi.openHotspotAsync(ssid, passphrase)

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -60,6 +60,12 @@
 					<p>Your device will soon be online. If connection is unsuccessful, the Access Point will be back up in a few minutes, and reloading this page will allow you to try again.</p>
 				</div>
 			</div>
+			<div class="row hidden" id='no-networks-message'>
+				<div class="col-lg-8 col-lg-offset-2">
+					<h3>No wifi networks available</h3>
+					<p>Please ensure there is a network within range and reboot the device.</p>
+				</div>
+			</div>
 		</div>
 	</body>
 </html>

--- a/src/public/js/index.js
+++ b/src/public/js/index.js
@@ -1,8 +1,13 @@
 $(function(){
 	$.get("/ssids", function(data){
-		$.each(data, function(i, val){
-			$("#ssid-select").append("<option value='" + val.ssid + "'>" + val.ssid + "</option>");
-		});		
+		if(data.length == 0){
+			$('.before-submit').hide();
+			$('#no-networks-message').removeClass('hidden');
+		} else {
+			$.each(data, function(i, val){
+				$("#ssid-select").append("<option value='" + val.ssid + "'>" + val.ssid + "</option>");
+			});
+		}
 	})
 
 	$('#connect-form').submit(function(ev){


### PR DESCRIPTION
Currently, as connman-simplified returns an error, when the scan results in no networks found we crash.
This PR fixes this by catching the error, and showing an error message on the web UI.