### PR TITLE
Longer retry to get the tether interface's IP

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -28,7 +28,7 @@ catch
 ignore = ->
 
 getIptablesRules = (callback) ->
-	async.retry {times: 100, interval: 100}, (cb) ->
+	async.retry {times: 100, interval: 200}, (cb) ->
 		Promise.try ->
 			os.networkInterfaces().tether[0].address
 		.nodeify(cb)


### PR DESCRIPTION
Might *possibly* fix #16 

We added the retry originally because connman takes a while to set up the interface, or it's appearance takes a while to be reflected in node's os.networkInterfaces(). With this change we will wait upto 20 seconds (instead of 10) for this to happen.