### PR TITLE
Use the more generic 0.10 tag on the Dockerfile

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node:0.10.40
+FROM resin/%%RESIN_MACHINE_NAME%%-node:0.10
 
 RUN apt-get update && apt-get install -y \
 	bind9 \


### PR DESCRIPTION
Using this tag avoids issues with non-existent device images. This can
happen if a new devices gets support in resin and at the time node
version has advanced, so old docker images don't exist.

Fixes #38

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>