### PR TITLE
freeze dbus module 0.2.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "body-parser": "^1.15.2",
     "bower": "^1.7.9",
     "coffee-script": "~1.9.3",
-    "dbus": "^0.2.19",
+    "dbus": "0.2.19",
     "express": "^4.14.0",
     "lodash": "^4.16.4"
   },


### PR DESCRIPTION
Latest version 0.2.19 of dbus breaks wifi-connect on startup. Freezing until we resolve the issue.

https://github.com/Shouqun/node-dbus/issues/159