### PR TITLE
Start NetworkManager after it's installed

### DIFF
--- a/scripts/raspbian-install.sh
+++ b/scripts/raspbian-install.sh
@@ -93,6 +93,12 @@ activate_network_manager() {
         ensure sudo apt-get install -y network-manager
 
         ensure sudo apt-get clean
+        
+        say 'Activating NetworkManager...'
+
+        ensure sudo systemctl enable NetworkManager
+
+        ensure sudo systemctl start NetworkManager
     else
         say 'NetworkManager is already installed'
 


### PR DESCRIPTION
We ran into the issue with the 4.0 version that NetworkManager was installed with the `raspbian-install.sh` script, but not started & enabled. This made the installation fail. 

Hope this can be merged or some other (perhaps prettier) solution :)