### PR TITLE
Interactive install from command line for Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ WiFi Connect depends on NetworkManager, but by default Raspbian Stretch uses dhc
 
 Run the following in your terminal, then follow the onscreen instructions:
 
-`curl https://github.com/resin-io/resin-wifi-connect/raw/master/scripts/raspbian-install.sh -sSfL | bash`
+`bash -c "$(curl https://github.com/resin-io/resin-wifi-connect/raw/master/scripts/raspbian-install.sh -sSfL)"`
 
 ### resinOS
 


### PR DESCRIPTION
Current example does auto cancel of install without asking the user if they would like to install needed dependencies. 
Also:
`curl https://github.com/resin-io/resin-wifi-connect/raw/master/scripts/raspbian-install.sh -sSfL -o raspbian-install.sh && bash ./raspbian-install.sh` 
would work as well