### PR TITLE
Remove blank/duplicate SSIDs from dropdown list

### DIFF
--- a/ui/js/index.js
+++ b/ui/js/index.js
@@ -5,7 +5,9 @@ $(function(){
 			$('#no-networks-message').removeClass('hidden');
 		} else {
 			$.each(JSON.parse(data), function(i, val){
-				$("#ssid-select").append($('<option>').attr('val', val).text(val));
+				if((val != '') && ($('#ssid-select option[val="' + val + '"]').length == 0)){
+					$("#ssid-select").append($('<option>').attr('val', val).text(val));
+				};
 			});
 		}
 	});


### PR DESCRIPTION
Blank entries will appear for hidden SSIDs, and duplicate entries will appear for multiple APs broadcasting the same SSID.

Small AND conditional wrapping the append call, preventing either/both of these scenarios.